### PR TITLE
Calculate quasi-probabilities using Statevector.probabilities

### DIFF
--- a/planning.ipynb
+++ b/planning.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "ddff49f46c0728ee",
    "metadata": {},
    "source": [
     "# Planning challenge Quantum workshop\n",
@@ -23,51 +24,51 @@
     "   1. [IBM Quantum](#ibm-backend)\n",
     "   2. [AWS Braket](#aws-backend)\n",
     "   3. [Quantum Inspire](#inspire-backend)"
-   ],
-   "id": "ddff49f46c0728ee"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "8d3d6441321fd651",
    "metadata": {},
    "source": [
     "## Problem Statement <a id=\"problem-statement\"></a>\n",
     "\n",
     "Here we want to elaborate a little on the problem, the approach and the reasoning."
-   ],
-   "id": "8d3d6441321fd651"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "ce0f96f1820b1d28",
    "metadata": {},
    "source": [
     "## System Prerequisites <a id=\"prerequisites\"></a>\n",
     "\n",
     "The only prerequisite to set up the workshop is [git](https://git-scm.com/) since the approach taken to install the python interpeter manager [pyenv](https://github.com/pyenv/pyenv), is based on git."
-   ],
-   "id": "ce0f96f1820b1d28"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "b4b32a7d47b721fb",
    "metadata": {},
    "source": [
     "## System Setup <a id=\"system-setup\"></a>\n",
     "\n",
     "The following instructions will guide through the full setup of the workshop in a deterministic and reproducible manner. If a user is advanced and knows how things are working they can choose an alternative approach, tool or setup."
-   ],
-   "id": "b4b32a7d47b721fb"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "a69929562b41428",
    "metadata": {},
    "source": [
     "### Editor <a id=\"editor\"></a>\n",
     "\n",
     "The suggested editor to use is [vscode](https://code.visualstudio.com/). Please use your prefered method of installation according to your tastes and operating system."
-   ],
-   "id": "a69929562b41428"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "9c7167e90c822b64",
    "metadata": {},
    "source": [
     "### Editor addons <a id=\"editor-addons\"></a>\n",
@@ -75,21 +76,21 @@
     "On [vscode](https://code.visualstudio.com/) the addons used for this workshop are [jupyter](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter) to use the actuall notebook and optionally [aws-toolkit](https://marketplace.visualstudio.com/items?itemName=AmazonWebServices.aws-toolkit-vscode) if you are interested in executing the code on AWS.\n",
     "\n",
     "Please install the jupiter plugin from the above link."
-   ],
-   "id": "9c7167e90c822b64"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "1395e2523c70f3ee",
    "metadata": {},
    "source": [
     "### Python interpreter manager (pyenv) <a id=\"pyenv-setup\"></a>\n",
     "\n",
     "We are using pyenv to manage multiple python versions and pin a specific one for this workwhop. Please follow the instructions per your operating system."
-   ],
-   "id": "1395e2523c70f3ee"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "d25c6a6259825bbb",
    "metadata": {},
    "source": [
     "#### pyenv on MacOS/Linux <a id=\"pyenv-unixes\"></a>\n",
@@ -123,11 +124,11 @@
     "```\n",
     "\n",
     "exit the interpreter."
-   ],
-   "id": "d25c6a6259825bbb"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "3a4dcef1975b121d",
    "metadata": {},
    "source": [
     "#### pyenv on Windows <a id=\"pyenv-win\"></a>\n",
@@ -157,11 +158,11 @@
     "```\n",
     "\n",
     "exit the interpreter."
-   ],
-   "id": "3a4dcef1975b121d"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "7d1867b03d4c00b1",
    "metadata": {},
    "source": [
     "### [pipx](https://pipx.pypa.io/stable/) Install and Run Python Applications in Isolated Environments <a id=\"pipx-setup\"></a>\n",
@@ -179,11 +180,11 @@
     "```bash\n",
     "    pipx ensurepath  # pipx.exe ensurepath (for windows)\n",
     "```\n"
-   ],
-   "id": "7d1867b03d4c00b1"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "5290d32fc1dcd554",
    "metadata": {},
    "source": [
     "### [pipenv](https://pipenv.pypa.io/en/latest/) Python virtualenv management tool and package manager <a id=\"pipenv-setup\"></a>\n",
@@ -211,29 +212,29 @@
     "$env:PIPENV_PYTHON=#TODO\n",
     "$env:PIPENV_VENV_IN_PROJECT=true\n",
     "```\n"
-   ],
-   "id": "5290d32fc1dcd554"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "566f7768eb5bf7f4",
    "metadata": {},
    "source": [
     "#### OS module is needed for all executions of code below so we install here"
-   ],
-   "id": "566f7768eb5bf7f4"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 125,
+   "id": "b2263d5dc92b6d54",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os"
-   ],
-   "id": "b2263d5dc92b6d54"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "b4b357da0e393f70",
    "metadata": {},
    "source": [
     "### Install all required dependencies for the workshop <a id=\"installing-dependencies\"></a> (in a shell execute)\n",
@@ -241,38 +242,38 @@
     "```bash\n",
     "pipenv install --dev\n",
     "```"
-   ],
-   "id": "b4b357da0e393f70"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "4b683a0fd631484f",
    "metadata": {},
    "source": [
     "### Install linters for quality <a id=\"installing-quality\"></a>"
-   ],
-   "id": "4b683a0fd631484f"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ef3b86f5c994b325",
    "metadata": {},
    "outputs": [],
    "source": [
     "os.system('pipenv install --categories quality')"
-   ],
-   "id": "ef3b86f5c994b325"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "f32208c12bf544df",
    "metadata": {},
    "source": [
     "### Lint the current code and sort imports <a id=\"linting\"></a>"
-   ],
-   "id": "f32208c12bf544df"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "634721c99d76e8c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -283,44 +284,43 @@
     "for command in commands:\n",
     "    print(f'Running {command}')\n",
     "    print(os.system(f'pipenv run {command}'))"
-   ],
-   "id": "634721c99d76e8c"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "586ca7db678a5b43",
    "metadata": {},
    "source": [
     "## Quantum Approach <a id=\"quantum-approach\"></a>"
-   ],
-   "id": "586ca7db678a5b43"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "29171b1739de1aee",
    "metadata": {},
    "source": [
     "### Suppress warnings for deprecation so the output is cleaner."
-   ],
-   "id": "29171b1739de1aee"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 128,
+   "id": "c0cfcb978df73212",
    "metadata": {},
    "outputs": [],
    "source": [
     "import warnings\n",
     "\n",
     "warnings.filterwarnings('ignore')"
-   ],
-   "id": "c0cfcb978df73212"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "cfb786592bcb354c",
    "metadata": {},
    "source": [
     "### Import required libraries"
-   ],
-   "id": "cfb786592bcb354c"
+   ]
   },
   {
    "cell_type": "code",
@@ -342,11 +342,11 @@
   },
   {
    "cell_type": "markdown",
+   "id": "57095c142822c672",
    "metadata": {},
    "source": [
     "#### Define the encoding for the problem"
-   ],
-   "id": "57095c142822c672"
+   ]
   },
   {
    "cell_type": "code",
@@ -381,15 +381,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5eaee7111418d4c7",
    "metadata": {},
    "source": [
     "#### Test the encoding "
-   ],
-   "id": "5eaee7111418d4c7"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f965bf602e111c92",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -403,16 +404,15 @@
     "\n",
     "\n",
     "unit_test_exhaustive()"
-   ],
-   "id": "f965bf602e111c92"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "e9bd8eceb8005b3a",
    "metadata": {},
    "source": [
     "### Define the cost function"
-   ],
-   "id": "e9bd8eceb8005b3a"
+   ]
   },
   {
    "cell_type": "code",
@@ -489,11 +489,11 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7a6b3031082df6b4",
    "metadata": {},
    "source": [
     "#### Visually validate the output of the cost function"
-   ],
-   "id": "7a6b3031082df6b4"
+   ]
   },
   {
    "cell_type": "code",
@@ -507,11 +507,11 @@
   },
   {
    "cell_type": "markdown",
+   "id": "12895f852217b858",
    "metadata": {},
    "source": [
     "### Define the circuit and train"
-   ],
-   "id": "12895f852217b858"
+   ]
   },
   {
    "cell_type": "code",
@@ -737,11 +737,11 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d46a7a0fd5a5e149",
    "metadata": {},
    "source": [
     "### Plot the progress of the training"
-   ],
-   "id": "d46a7a0fd5a5e149"
+   ]
   },
   {
    "cell_type": "code",
@@ -802,10 +802,10 @@
     "\n",
     "ansatz_plot = ansatz.assign_parameters(result.optimal_parameters)\n",
     "state = Statevector(ansatz_plot)\n",
-    "plt.bar(np.arange(len(state)),(state.data**2).real)\n",
+    "plt.bar(np.arange(len(state)), state.probabilities())\n",
     "#plt.xticks(np.arange(2**(NUM_PROJECTS*NUM_WORKERS*NUM_DIGITS)))# ,[\"|000>\",\"|001>\",\"|010>\",\"|011>\",\"|100>\",\"|101>\",\"|110>\",\"|111>\"])\n",
     "\n",
-    "for i, value in enumerate((state.data**2).real):\n",
+    "for i, value in enumerate(state.probabilities()):\n",
     "    plt.plot(i, value, marker='o', markersize=2, color='red')\n",
     "\n",
     "plt.ylabel(\"Probability to measure state\")\n",
@@ -847,7 +847,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# np.argsort(state.data**2)[::-1]"
+    "# np.argsort(state.probabilities())[::-1]"
    ]
   },
   {
@@ -857,7 +857,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# (state.data**2)[2694]"
+    "# state.probabilities()[2694]"
    ]
   },
   {
@@ -867,16 +867,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# np.sort(state.data**2)[::-1]"
+    "# np.sort(state.probabilities())[::-1]"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "3021cb85ff56708",
    "metadata": {},
    "source": [
     "### Create the bound circuit to be used for all remote backend providers."
-   ],
-   "id": "3021cb85ff56708"
+   ]
   },
   {
    "cell_type": "code",
@@ -1282,15 +1282,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8269014e41499b4d",
    "metadata": {},
    "source": [
     "### We need to format the exported OpenQASM to remove IBM specific input so it can be executed on other backends."
-   ],
-   "id": "8269014e41499b4d"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 143,
+   "id": "cdf2436a22d969c8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1301,55 +1302,55 @@
     "    circuit += '\\n'.join([line for line in bound_c.qasm().splitlines()[2:] \n",
     "                          if not line.startswith('barrier')])\n",
     "    return circuit"
-   ],
-   "id": "cdf2436a22d969c8"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "1a02ef027ff71bae",
    "metadata": {},
    "source": [
     "## Execution on remote backends <a id=\"remote-backends\"></a>"
-   ],
-   "id": "1a02ef027ff71bae"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "2c3eed85ba956ddb",
    "metadata": {},
    "source": [
     "### IBM Quantum <a id=\"ibm-backend\"></a>"
-   ],
-   "id": "2c3eed85ba956ddb"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "308ebb7990aa78e",
    "metadata": {},
    "source": [
     "### Prerequisites \n",
     "\n",
     "To execute the job on IBM backend an account is required to be created for valid credentials on [quantum.ibm](https://quantum.ibm.com/)"
-   ],
-   "id": "308ebb7990aa78e"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "9c1a9bc6a102682b",
    "metadata": {},
    "source": [
     "#### install requirements for the IBM backend"
-   ],
-   "id": "9c1a9bc6a102682b"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "651a13bbb933c151",
    "metadata": {},
    "outputs": [],
    "source": [
     "os.system('pipenv install --categories ibm-backend')"
-   ],
-   "id": "651a13bbb933c151"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "c5c6c34f69dad084",
    "metadata": {},
    "source": [
     "### Set the backend token required from the valid account setup on quantum IBM.\n",
@@ -1358,32 +1359,32 @@
     "```bash\n",
     "IBM_BACKEND_TOKEN=\"YOUR_TOKEN_HERE\"\n",
     "```"
-   ],
-   "id": "c5c6c34f69dad084"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 152,
+   "id": "8e171b3235290127",
    "metadata": {},
    "outputs": [],
    "source": [
     "from dotenv import load_dotenv\n",
     "load_dotenv()\n",
     "IBM_BACKEND_TOKEN = os.environ.get('IBM_BACKEND_TOKEN')"
-   ],
-   "id": "8e171b3235290127"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "7d58ee43c7ecb268",
    "metadata": {},
    "source": [
     "#### Import requirements"
-   ],
-   "id": "7d58ee43c7ecb268"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "bd53d435ef2abc55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1400,20 +1401,20 @@
     "sampler = Sampler(backend=backend, options=options)\n",
     "job = sampler.run(circuits=bound_c, shots=100)\n",
     "print(job.result())"
-   ],
-   "id": "bd53d435ef2abc55"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "98309799f9d6b621",
    "metadata": {},
    "source": [
     "### Validate the execution result"
-   ],
-   "id": "98309799f9d6b621"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 154,
+   "id": "29ac132bbdfb25f7",
    "metadata": {},
    "outputs": [
     {
@@ -1451,12 +1452,12 @@
     "             bbox=dict(boxstyle='round,pad=0.3', edgecolor='black', facecolor='white'),\n",
     "             fontsize=18,\n",
     "             )"
-   ],
-   "id": "29ac132bbdfb25f7"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 155,
+   "id": "c7931d9dd52ee912",
    "metadata": {},
    "outputs": [
     {
@@ -1474,12 +1475,12 @@
     "d = job.result().quasi_dists[0]\n",
     "\n",
     "max(d, key=d.get)"
-   ],
-   "id": "c7931d9dd52ee912"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 156,
+   "id": "1e9b8c70a229271f",
    "metadata": {},
    "outputs": [
     {
@@ -1494,13 +1495,13 @@
     }
    ],
    "source": [
-    "(state.data**2)[2694]"
-   ],
-   "id": "1e9b8c70a229271f"
+    "state.probabilities()[2694]"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8d0ae7cbefc95c8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1509,19 +1510,19 @@
     "\n",
     "df = pd.DataFrame(result_bit)\n",
     "print(df)"
-   ],
-   "id": "8d0ae7cbefc95c8"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "ccb21a46c2c411a2",
    "metadata": {},
    "source": [
     "### AWS Braket <a id=\"aws-backend\"></a>"
-   ],
-   "id": "ccb21a46c2c411a2"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "d9d02eb46911f85b",
    "metadata": {},
    "source": [
     "#### Prerequisites\n",
@@ -1529,38 +1530,38 @@
     "To execute the job on AWS Braket the service needs to be properly [enabled](https://docs.aws.amazon.com/braket/latest/developerguide/braket-enable-overview.html). \n",
     "\n",
     "To be able to submit the job we also need to have [aws cli](https://aws.amazon.com/cli/) properly [installed](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) and properly [configured](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) for access. Also the [aws-toolkit](https://marketplace.visualstudio.com/items?itemName=AmazonWebServices.aws-toolkit-vscode) needs to be installed and a profile needs to be chosen that corresponds with the active profile that provides access to the properly configured AWS Braket service."
-   ],
-   "id": "d9d02eb46911f85b"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "8286d17f3890e3dc",
    "metadata": {},
    "source": [
     "#### install requirements for the AWS Braket backend"
-   ],
-   "id": "8286d17f3890e3dc"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "644781d4130d451a",
    "metadata": {},
    "outputs": [],
    "source": [
     "os.system('pipenv install --categories aws-backend')"
-   ],
-   "id": "644781d4130d451a"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "dbe78c78172b11db",
    "metadata": {},
    "source": [
     "AWS OpenQASM is not absolutelly compatible with IBM OpenQASM that gets exported from the bound circuit so we need to tweak the circuit a little to execute on AWS."
-   ],
-   "id": "dbe78c78172b11db"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 159,
+   "id": "f79b101e5a2f1c6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1573,11 +1574,11 @@
     "                return line.replace(original, replacement)\n",
     "        return line \n",
     "    return ''.join([to_aws_qasm(line) for line in get_qasm_from_bound_c(bound_c)])"
-   ],
-   "id": "f79b101e5a2f1c6"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "3db8668ab565c870",
    "metadata": {},
    "source": [
     "#### Set active profile name with access to Braket and region\n",
@@ -1587,12 +1588,12 @@
     "BRAKET_PROFILE=\"Braket-Admin\"\n",
     "BRAKET_REGION=\"eu-west-2\"\n",
     "```"
-   ],
-   "id": "3db8668ab565c870"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 160,
+   "id": "835cf851c7772cf0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1600,12 +1601,12 @@
     "load_dotenv()\n",
     "BRAKET_PROFILE = os.environ.get('BRAKET_PROFILE')\n",
     "BRAKET_REGION = os.environ.get('BRAKET_REGION')"
-   ],
-   "id": "835cf851c7772cf0"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 161,
+   "id": "60b16688915160d6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1618,12 +1619,12 @@
     "                                              region_name=BRAKET_REGION))\n",
     "# We are going to use sv1 remote simulator as that is the only one compatible with our circuit (gate based)\n",
     "device = AwsDevice(\"arn:aws:braket:::device/quantum-simulator/amazon/sv1\", aws_session=aws_session)"
-   ],
-   "id": "60b16688915160d6"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 162,
+   "id": "157ffc00a5347344",
    "metadata": {},
    "outputs": [
     {
@@ -1642,67 +1643,67 @@
     "print(result)\n",
     "# The result of the run can be retrieved from the configured s3 backet of the Braket service\n",
     "# by following the quantum task information on the quantum tasks tab of the the braket service."
-   ],
-   "id": "157ffc00a5347344"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "4db207ae0a972065",
    "metadata": {},
    "source": [
     "### Quantum Inspire <a id=\"inspire-backend\"></a>"
-   ],
-   "id": "4db207ae0a972065"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "fd1be696956740b0",
    "metadata": {},
    "source": [
     "#### Prerequisites\n",
     "\n",
     "To execute the job on Quantum inspire backend an account is required to be created for valid credentials on [quantum-inspire](https://www.quantum-inspire.com/)"
-   ],
-   "id": "fd1be696956740b0"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "2b71533082e05d60",
    "metadata": {},
    "source": [
     "#### Install requirements for the Inspire backend"
-   ],
-   "id": "2b71533082e05d60"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8d7fc157b00aac34",
    "metadata": {},
    "outputs": [],
    "source": [
     "os.system('pipenv install --categories inspire-backend')"
-   ],
-   "id": "8d7fc157b00aac34"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "dda474525ab6ae6e",
    "metadata": {},
    "source": [
     "### Set the backend variables required from the valid account setup on quantum inspire."
-   ],
-   "id": "dda474525ab6ae6e"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "7d9cb93a7d5e2d98",
    "metadata": {},
    "source": [
     "In a .env file in the root of the project set the required variable\n",
     "```bash\n",
     "INSPIRE_TOKEN='YOUR_TOKEN_HERE'\n",
     "```\n"
-   ],
-   "id": "7d9cb93a7d5e2d98"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 165,
+   "id": "e3ab8e1525cd0a8d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1712,12 +1713,12 @@
     "INSPIRE_TOKEN=os.environ.get('INSPIRE_TOKEN')\n",
     "INSPIRE_DEVICE_ID = 'QX-34-L' # The only backend that can run our job, a simulator.\n",
     "INSPIRE_SERVER_URL = r'https://api.quantum-inspire.com'"
-   ],
-   "id": "e3ab8e1525cd0a8d"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "24b2b17bf311095",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1731,16 +1732,15 @@
     "backend_type = qi.get_backend_type_by_name(INSPIRE_DEVICE_ID)\n",
     "result = qi.execute_qasm(get_qasm_from_bound_c(bound_c), backend_type=backend_type, number_of_shots=100)\n",
     "print(result)"
-   ],
-   "id": "24b2b17bf311095"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "5ccb255ca9407a8b",
    "metadata": {},
    "source": [
     "#### The inspire backend is not really supported and probably not functioning at all"
-   ],
-   "id": "5ccb255ca9407a8b"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
This PR changes the calculation of the quasi-probabilities to use the Qiskit [Statevector.probabilities](https://docs.quantum.ibm.com/api/qiskit/qiskit.quantum_info.Statevector#probabilities) method. This ensures that the calculation gives sensible results when elements of `Statevector.data` have a non-zero imaginary part.  